### PR TITLE
feat(placeholder-support): added placeholder for pickers

### DIFF
--- a/src/components/AbstractSelectInput/AbstractSelectInput.js
+++ b/src/components/AbstractSelectInput/AbstractSelectInput.js
@@ -45,8 +45,10 @@ class AbstractSelectInput extends Component {
   }
 
   getValueLabel = () => {
-    const { options, value } = this.props
+    const { options, value, placeholder } = this.props
     const valueOptions = options || [{ value: '', label: '' }]
+
+    if (!value && placeholder) return placeholder
 
     return (
       valueOptions.map(function(option) {

--- a/src/components/SelectInput.android/SelectInput.js
+++ b/src/components/SelectInput.android/SelectInput.js
@@ -16,7 +16,8 @@ class SelectInput extends AbstractSelectInput {
       options,
       style,
       backgroundColor,
-      dropdownIconColor
+      dropdownIconColor,
+      placeholder
     } = this.props
     const { selectedValue } = this.state
 
@@ -31,6 +32,9 @@ class SelectInput extends AbstractSelectInput {
           selectedValue={selectedValue}
           mode={mode}
         >
+          {!!placeholder && (
+            <Picker.Item key={placeholder} value="" label={placeholder} />
+          )}
           {options.map(option => (
             <Picker.Item
               key={option.value}


### PR DESCRIPTION
 - in IOS it works perfect, as we implement picker in custom-keyboard component.
 - for android, we need to add an extra item in the `Picker.item` list as placeholder value.
There is drawback of this approach in android that, the placeholder will appear as first value in drop-down list of picker

Added tag for this version as `v2.0.5+waam-app.9`